### PR TITLE
update theme with light mode and dark mode

### DIFF
--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -8,16 +8,46 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg transition-all duration-300 hover:scale-105"
+      className="p-1 hover:opacity-70 transition-opacity duration-200"
       style={{
-        backgroundColor: theme === 'dark' ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.05)',
-        color: theme === 'dark' ? '#f9fafb' : '#1f2937',
-        border: `1px solid ${theme === 'dark' ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.1)'}`,
+        background: 'none',
+        border: 'none',
+        color: theme === 'dark' ? '#f9fafb' : '#374151',
       }}
       aria-label="Toggle theme"
       title={`Switch to ${theme === 'light' ? 'dark' : 'light'} theme`}
     >
-      {theme === 'light' ? '�' : '☀️'}
+      {theme === 'light' ? (
+        <svg 
+          xmlns="http://www.w3.org/2000/svg" 
+          fill="none" 
+          viewBox="0 0 24 24" 
+          strokeWidth="1.5" 
+          stroke="currentColor" 
+          className="w-6 h-6"
+        >
+          <path 
+            strokeLinecap="round" 
+            strokeLinejoin="round" 
+            d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" 
+          />
+        </svg>
+      ) : (
+        <svg 
+          xmlns="http://www.w3.org/2000/svg" 
+          fill="none" 
+          viewBox="0 0 24 24" 
+          strokeWidth="1.5" 
+          stroke="currentColor" 
+          className="w-6 h-6"
+        >
+          <path 
+            strokeLinecap="round" 
+            strokeLinejoin="round" 
+            d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" 
+          />
+        </svg>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
This pull request updates the `ThemeToggle` component to improve its appearance and accessibility. The main changes include simplifying the button's styling, removing custom backgrounds and borders, and replacing emoji icons with accessible SVG icons for light and dark themes.

Styling simplification:

* Updated the button's class and inline styles in `ThemeToggle.tsx` to remove custom backgrounds, borders, and padding, resulting in a cleaner and more consistent appearance across themes.

Accessibility and icon improvements:

* Replaced emoji icons with SVG icons for both light and dark themes, providing better accessibility and a more professional look.